### PR TITLE
RF: update logger

### DIFF
--- a/src/grg_sphinx_theme/team.py
+++ b/src/grg_sphinx_theme/team.py
@@ -2,8 +2,9 @@ import os
 import json
 from urllib.request import Request, urlopen
 from sphinx.application import Sphinx
-from sphinx.util import logger
+from sphinx.util import logging
 
+logger = logging.getLogger(__name__)
 GH_TOKEN = os.environ.get('GH_TOKEN', '')
 BASE_URL = 'https://api.github.com/'
 


### PR DESCRIPTION
fix the logger issue below from the last Sphinx release (8.2.0)

```python
Extension error!

Versions
========

* Platform:         linux; (Linux-6.8.0-1021-azure-x86_64-with-glibc2.39)
* Python version:   3.11.11 (CPython)
* Sphinx version:   8.2.0
* Docutils version: 0.21.2
* Jinja2 version:   3.1.5
* Pygments version: 2.19.1

Last Messages
=============

None.

Loaded Extensions
=================

None.

Traceback
=========

      File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/sphinx/registry.py", line 544, in load_extension
        raise ExtensionError(
    sphinx.errors.ExtensionError: Could not import extension grg_sphinx_theme (exception: cannot import name 'logger' from 'sphinx.util' (/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/sphinx/util/__init__.py))


The full traceback has been saved in:
/tmp/sphinx-err-a8rye1un.log
```